### PR TITLE
Flip tooltip position when its rendered beyond screen plot

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sticky-mouse-tooltip",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "main": "dist/MouseTooltip.js",
   "files": ["dist/*"],
   "author": "marlo22",

--- a/src/MouseTooltip.jsx
+++ b/src/MouseTooltip.jsx
@@ -8,11 +8,18 @@ class MouseTooltip extends React.PureComponent {
     offsetY: 0,
   };
 
+  constructor(props) {
+    super(props);
+    this.containerRef = React.createRef();
+  }
+
   state = {
     xPosition: 0,
     yPosition: 0,
     mouseMoved: false,
     listenerActive: false,
+    shouldFlipHorizontally: false,
+    shouldFlipVertically: false,
   };
 
   componentDidMount() {
@@ -28,10 +35,18 @@ class MouseTooltip extends React.PureComponent {
   }
 
   getTooltipPosition = ({ clientX: xPosition, clientY: yPosition }) => {
+    const screenWidth = window.innerWidth;
+    const screenHeight = window.innerHeight;
+    const containerWidth = this.containerRef.current.clientWidth;
+    const containerHeight = this.containerRef.current.clientHeight;
+    const shouldFlipHorizontally = (xPosition + containerWidth > screenWidth);
+    const shouldFlipVertically = (yPosition + containerHeight > screenHeight);
     this.setState({
       xPosition,
       yPosition,
       mouseMoved: true,
+      shouldFlipHorizontally,
+      shouldFlipVertically,
     });
   };
 
@@ -56,14 +71,21 @@ class MouseTooltip extends React.PureComponent {
   };
 
   render() {
+    const left = (this.state.shouldFlipHorizontally
+      ? this.state.xPosition - this.containerRef.current.clientWidth - this.props.offsetX
+      : this.state.xPosition + this.props.offsetX);
+    const top = (this.state.shouldFlipVertically
+      ? this.state.yPosition - this.containerRef.current.clientHeight - this.props.offsetY
+      : this.state.yPosition + this.props.offsetY);
     return (
       <div
         className={this.props.className}
+        ref={this.containerRef}
         style={{
           display: this.props.visible && this.state.mouseMoved ? 'block' : 'none',
           position: 'fixed',
-          top: this.state.yPosition + this.props.offsetY,
-          left: this.state.xPosition + this.props.offsetX,
+          top,
+          left,
           ...this.props.style,
         }}
       >


### PR DESCRIPTION
## Description

Render tooltip from the opposite side of mouse (using same offset but in opposite direction) when mouse is positioned so close to screen edge that tooltip is rendered beyond the plot hiding it's content.


## Before (mouse cursor does not appear on screenshot):

<img width="82" alt="Screen Shot 2021-06-18 at 3 33 06" src="https://user-images.githubusercontent.com/720339/122488582-6fcbff80-cfe6-11eb-9fe9-8783ef818173.png">


## After:

<img width="187" alt="Screen Shot 2021-06-18 at 3 30 28" src="https://user-images.githubusercontent.com/720339/122488605-78243a80-cfe6-11eb-9006-8fd3f686a8d0.png">

